### PR TITLE
Axes [breaking change]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIRTjim"
 uuid = "170b2178-6dee-4cb0-8729-b3e8b57834cc"
 authors = ["Jeff Fessler <fessler@umich.edu> and contributors"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 FFTViews = "4f61f5a4-77b1-5117-aa51-3ab5ef4ef0cd"

--- a/src/jim.jl
+++ b/src/jim.jl
@@ -140,7 +140,7 @@ function jim(z::AbstractArray{<:Real} ;
             ylabel,
             xtick,
             ytick,
-            annotate = (x[end÷2], y[end÷2], tmp, :red),
+            annotate = (x[(end+1)÷2], y[(end+1)÷2], tmp, :red),
             kwargs...
         )
     else

--- a/src/jim.jl
+++ b/src/jim.jl
@@ -6,7 +6,7 @@ jiffy image display
 
 export jim
 
-using Plots: heatmap, plot, plot!, annotate!
+using Plots: heatmap, plot, plot!
 using MosaicViews: mosaicview
 using FFTViews: FFTView
 
@@ -68,8 +68,8 @@ option
 - `ylabel`; default `""`
 - `yflip`; default `true` if `minimum(y) >= 0`
 - `yreverse`; default `true` if `y[1] > y[end]`
-- `x` values for x axis; default `1:size(z,1)`
-- `y` values for y axis; default `1:size(z,2)`
+- `x` values for x axis; default `collect(axes(z)[1])`
+- `y` values for y axis; default `collect(axes(z)[2])`
 - `xtick`; default `[minimum(x),maximum(x)]`
 - `ytick`; default `[minimum(y),maximum(y)]`
 
@@ -92,8 +92,8 @@ function jim(z::AbstractArray{<:Real} ;
     xlabel::AbstractString = jim_def[:xlabel],
     ylabel::AbstractString = jim_def[:ylabel],
     fft0::Bool = jim_def[:fft0],
-    x = fft0 ? ((-size(z,1)÷2):(size(z,1)÷2-1)) : (1:size(z,1)),
-    y = fft0 ? ((-size(z,2)÷2):(size(z,2)÷2-1)) : (1:size(z,2)),
+    x = fft0 ? ((-size(z,1)÷2):(size(z,1)÷2-1)) : collect(axes(z)[1]),
+    y = fft0 ? ((-size(z,2)÷2):(size(z,2)÷2-1)) : collect(axes(z)[2]),
     xtick = (minimum(x) < 0 && maximum(x) > 0) ?
         [minfloor(x),0,maxceil(x)] : [minfloor(x),maxceil(x)],
     ytick = (minimum(y) < 0 && maximum(y) > 0) ?
@@ -120,7 +120,7 @@ function jim(z::AbstractArray{<:Real} ;
         n2 += mosaic_npad
         n3 = size(z,3)
         if ncol == 0
-            ncol = Int(floor(sqrt(prod(size(z)[3:end]))))
+            ncol = floor(Int, sqrt(prod(size(z)[3:end])))
         end
         z = mosaicview(z ; fillvalue = padval, ncol, npad = mosaic_npad)
         xy = () # no x,y for mosaic
@@ -129,22 +129,20 @@ function jim(z::AbstractArray{<:Real} ;
     end
 
     if minimum(z) ≈ maximum(z) # uniform or nearly uniform image
-        x = 1:size(z,1)
-        y = 1:size(z,2)
+        tmp = (minimum(z) == maximum(z)) ? "Uniform $(z[1])" :
+            "Nearly uniform $((minimum(z),maximum(z)))"
         plot( ; aspect_ratio,
-            xlim = [x[1], x[end]],
-            ylim = [y[1], y[end]],
+            xlim = (x[1], x[end]),
+            ylim = (y[1], y[end]),
             title,
             yflip,
             xlabel,
             ylabel,
             xtick,
             ytick,
+            annotate = (x[end÷2], y[end÷2], tmp, :red),
             kwargs...
         )
-        tmp = (minimum(z) == maximum(z)) ? "Uniform $(z[1])" :
-            "Nearly uniform $((minimum(z),maximum(z)))"
-        annotate!((sum(x)/length(x), sum(y)/length(y), tmp, :red))
     else
         heatmap(xy..., z' ;
             transpose = false,

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,11 +1,13 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ffcfa2d345aaee0ef3d8346a073d5dd03c983ebe"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.2.0"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -16,12 +18,25 @@ git-tree-sha1 = "c7f1c695e06c01b95a67f0cd1d34994f3e7db104"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.2.1"
 
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[OffsetArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "b3dfef5f2be7d7eb0e782ba9146a5271ee426e90"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.6.2"
 
 [[Random]]
 deps = ["Serialization"]
@@ -30,9 +45,6 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/jim.jl
+++ b/test/jim.jl
@@ -2,6 +2,7 @@
 
 using MIRTjim: jim
 using LaTeXStrings
+using OffsetArrays: OffsetArray
 using Test: @test, @test_throws
 
 
@@ -20,6 +21,7 @@ jim(zeros(4,5), x=1:4, y=5:9, title="test3")
 jim(rand(6,4), fft0=true)
 jim(x=1:4, y=5:9, rand(4,5), title="test4")
 jim(x=-9:9, y=9:-1:-9, (-9:9) * (abs.((9:-1:-9) .- 5) .< 3)', title="rev")
+jim(OffsetArray(rand(5,3), (-3,-2)), "offset")
 jim(ones(3,3)) # uniform
 jim(:abswarn, false)
 jim(complex(rand(4,3)))


### PR DESCRIPTION
Use axes instead of `1:size(z,1)`
which is slightly breaking because default axes behavior changes for OffsetArrays,
but in a sensible way.
Had to use `collect` because currently `heatmap` throws error for `OffsetArrays.IdOffsetRange`

```
using Plots: heatmap
using OffsetArrays
x = OffsetArray(rand(5,3), (-2,-1))
heatmap(x)
```

Returns:
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: DimensionMismatch("new dimensions (6,) must be consistent with array size 15")
